### PR TITLE
Fixes for godot 3.1

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -1,7 +1,10 @@
 # SCsub
 Import('env')
+Import('env_modules')
 
-if env['tools'] == 'yes' and env['gdscript'] == 'yes':
-    env.add_source_files(env.modules_sources,'*.cpp')
+env_autocomplete_service = env_modules.Clone()
+
+if env['tools'] and env['gdscript']:
+    env_autocomplete_service.add_source_files(env.modules_sources,'*.cpp')
 else:
-    env.add_source_files(env.modules_sources,'register_types.cpp')
+    env_autocomplete_service.add_source_files(env.modules_sources,'register_types.cpp')

--- a/code_completion_server.cpp
+++ b/code_completion_server.cpp
@@ -280,7 +280,7 @@ void CodeCompletionServer::_add_to_servers_list() {
 
 CodeCompletionServer::CodeCompletionServer() {
 
-	server = Ref<TCP_Server>();
+	server.instance();
 	wait_mutex = Mutex::create();
 	quit = false;
 	active = false;

--- a/code_completion_server.h
+++ b/code_completion_server.h
@@ -5,6 +5,7 @@
 #include "../../core/object.h"
 #include "../../core/os/thread.h"
 #include "../../core/io/tcp_server.h"
+#include "../../core/bind/core_bind.h"
 #include "code_completion_service.h"
 
 class CodeCompletionServer : public Object {

--- a/code_completion_service.cpp
+++ b/code_completion_service.cpp
@@ -82,7 +82,7 @@ String CodeCompletionService::_get_text_for_completion(const Request& p_request,
 		if (i!=len-1)
 			r_text+="\n";
 	}
-
+	// FIXME: check bounds!
 	return substrings[p_request.row];
 }
 

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,7 +1,7 @@
 /* register_types.cpp */
 #include "register_types.h"
 
-#if defined(TOOLS_ENABLED) && defined(TOOLS_ENABLED)
+#ifdef TOOLS_ENABLED
 #define AUTOCOMPLETE_SERVICE
 #endif
 


### PR DESCRIPTION
This makes the module compile and work on the current godot master branch. In works in that I get reasonable completions and error messages. 
There are two spots I marked with TODO. One is a missing bounds check when the cursor is outside of the provided text. The other is in CodeCompletionService::_get_text_for_completion:191. I am not sure what ObjectTypeDB::get_type_list(&type_keywords); did.