### PR TITLE
Remove deprecated checks that cause early exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.o
 *.pyc
 .fscache
-
+*.obj

--- a/code_completion_service.cpp
+++ b/code_completion_service.cpp
@@ -24,9 +24,6 @@ CodeCompletionService::Result CodeCompletionService::obtain_suggestions(const Re
 
 	String path = ProjectSettings::get_singleton()->localize_path(p_request.script_path);
 
-	if (path == "res://" || !path.begins_with("res://"))
-		return Result();
-
 	Ref<Script> script = ResourceLoader::load(path);
 
 	if (!script.is_valid() || !Object::cast_to<GDScript>(*script))


### PR DESCRIPTION
`ProjectSettings->localize_path` (formally GlobalSettings) now returns
absolute paths (circa October 2016), so checking that a path has been
fully localized can fail prematurely.

We should be able to check results of the subsequent load to validate the
file (and path) are correct.

Also removing Scons build files from git ignore.